### PR TITLE
Add node age field

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Parameters related to the node that is initiating the channel.
 
 | Name | Type | Description |
 | -- | -- | -- |
-| **capacity** | range | Peer's node capacity |
+| **age** | range | Peer node age in blocks, based on the oldest announced channel |
+| **capacity** | range | Peer node capacity |
 | **hybrid** | boolean | Whether the peer will be required to be hybrid |
 | **feature_flags** | []int | Feature flags the peer node must know. Check out [lnrpc.FeatureBit](https://lightning.engineering/api-docs/api/lnd/lightning/query-routes#lnrpcfeaturebit) |
 | **Channels** | [Channels](#Channels) | Initiator node channels |
@@ -150,8 +151,8 @@ Parameters related to the initiator node's channels.
 | Name | Type | Description |
 | -- | -- | -- |
 | **number** | range | Peer's number of channels |
-| **zero_base_fees** | boolean | Whether the peer's channels must all have zero base fees |
 | **capacity** | stat_range | Channels size |
+| **zero_base_fees** | boolean | Whether the peer's channels must all have zero base fees |
 | **block_height** | stat_range | Channels block height |
 | **time_lock_delta** | stat_range | Channels time lock delta |
 | **min_htlc** | stat_range | Channels minimum HTLC |

--- a/examples/advanced.yml
+++ b/examples/advanced.yml
@@ -6,6 +6,8 @@ policies:
       channel_reserve:
         max: 50_000
     node:
+      age:
+        min: 52_560
       channels:
         outgoing_fee_rate:
           operation: median

--- a/examples/channels.yml
+++ b/examples/channels.yml
@@ -1,3 +1,4 @@
+# Set channel capacity requirements based on the initiator node's number of channels
 policies:
 	-
     conditions:

--- a/policy/channels.go
+++ b/policy/channels.go
@@ -26,7 +26,7 @@ type Channels struct {
 	OutgoingDisabled *StatRange[float64] `yaml:"outgoing_disabled,omitempty"`
 }
 
-func (c *Channels) evaluate(nodePubKey string, peer *lnrpc.NodeInfo) error {
+func (c *Channels) evaluate(nodePublicKey string, peer *lnrpc.NodeInfo) error {
 	if c == nil {
 		return nil
 	}
@@ -63,7 +63,7 @@ func (c *Channels) evaluate(nodePubKey string, peer *lnrpc.NodeInfo) error {
 		return errors.New("Channels last update " + c.LastUpdateDiff.Reason())
 	}
 
-	if !c.checkTogether(nodePubKey, peer) {
+	if !c.checkTogether(nodePublicKey, peer) {
 		return errors.New("Channels together " + c.Together.Reason())
 	}
 

--- a/policy/condition.go
+++ b/policy/condition.go
@@ -18,18 +18,18 @@ type Conditions struct {
 // Match returns true if all the conditions Match.
 func (c *Conditions) Match(
 	req *lnrpc.ChannelAcceptRequest,
-	nodePubKey string,
-	peerNode *lnrpc.NodeInfo,
+	node *lnrpc.GetInfoResponse,
+	peer *lnrpc.NodeInfo,
 ) bool {
 	if c == nil {
 		return true
 	}
 
-	if c.checkWhitelist(peerNode.Node.PubKey) {
+	if c.checkWhitelist(peer.Node.PubKey) {
 		return true
 	}
 
-	if !c.checkBlacklist(peerNode.Node.PubKey) {
+	if !c.checkBlacklist(peer.Node.PubKey) {
 		return false
 	}
 
@@ -45,7 +45,7 @@ func (c *Conditions) Match(
 		return false
 	}
 
-	if err := c.Node.evaluate(nodePubKey, peerNode); err != nil {
+	if err := c.Node.evaluate(node, peer); err != nil {
 		return false
 	}
 

--- a/policy/condition_test.go
+++ b/policy/condition_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMatch(t *testing.T) {
-	nodePublicKey := "node_public_key"
+	node := &lnrpc.GetInfoResponse{IdentityPubkey: "node_public_key"}
 	peerPublicKey := "peer_public_key"
 	defaultReq := &lnrpc.ChannelAcceptRequest{}
 	defaultPeer := &lnrpc.NodeInfo{
@@ -118,7 +118,7 @@ func TestMatch(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			actual := tc.conditions.Match(tc.req, nodePublicKey, tc.peer)
+			actual := tc.conditions.Match(tc.req, node, tc.peer)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}

--- a/policy/node.go
+++ b/policy/node.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"errors"
+	"math"
 	"strings"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -9,30 +10,56 @@ import (
 
 // Node represents a set of requirements the node requesting to open a channel must satisfy.
 type Node struct {
+	Age          *Range[uint32]      `yaml:"age,omitempty"`
 	Capacity     *Range[int64]       `yaml:"capacity,omitempty"`
 	Hybrid       *bool               `yaml:"hybrid,omitempty"`
 	FeatureFlags *[]lnrpc.FeatureBit `yaml:"feature_flags,omitempty"`
 	Channels     *Channels           `yaml:"channels,omitempty"`
 }
 
-func (n *Node) evaluate(nodePubKey string, peerNode *lnrpc.NodeInfo) error {
+func (n *Node) evaluate(node *lnrpc.GetInfoResponse, peer *lnrpc.NodeInfo) error {
 	if n == nil {
 		return nil
 	}
 
-	if !check(n.Capacity, peerNode.TotalCapacity) {
+	if !n.checkAge(node.BlockHeight, peer.Channels) {
+		return errors.New("Node age " + n.Age.Reason())
+	}
+
+	if !check(n.Capacity, peer.TotalCapacity) {
 		return errors.New("Node capacity " + n.Capacity.Reason())
 	}
 
-	if !n.checkHybrid(peerNode.Node.Addresses) {
+	if !n.checkHybrid(peer.Node.Addresses) {
 		return errors.New("Node doesn't have both clearnet and tor addresses")
 	}
 
-	if !n.checkFeatureFlags(peerNode.Node.Features) {
+	if !n.checkFeatureFlags(peer.Node.Features) {
 		return errors.New("Node doesn't have the desired feature flags")
 	}
 
-	return n.Channels.evaluate(nodePubKey, peerNode)
+	return n.Channels.evaluate(node.IdentityPubkey, peer)
+}
+
+func (n *Node) checkAge(bestBlockHeight uint32, channels []*lnrpc.ChannelEdge) bool {
+	if n.Age == nil {
+		return true
+	}
+
+	if len(channels) == 0 {
+		return n.Age.Contains(0)
+	}
+
+	oldestChannel := uint32(math.MaxInt32)
+	for _, channel := range channels {
+		blockHeight := uint32(channel.ChannelId >> 40)
+		if blockHeight < oldestChannel {
+			oldestChannel = blockHeight
+		}
+	}
+
+	difference := bestBlockHeight - oldestChannel
+	return n.Age.Contains(difference)
 }
 
 func (n *Node) checkHybrid(addresses []*lnrpc.NodeAddress) bool {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -25,10 +25,10 @@ type Policy struct {
 // Evaluate set of policies.
 func (p *Policy) Evaluate(
 	req *lnrpc.ChannelAcceptRequest,
-	nodePublicKey string,
+	node *lnrpc.GetInfoResponse,
 	peerNode *lnrpc.NodeInfo,
 ) error {
-	if p.Conditions != nil && !p.Conditions.Match(req, nodePublicKey, peerNode) {
+	if p.Conditions != nil && !p.Conditions.Match(req, node, peerNode) {
 		return nil
 	}
 
@@ -56,7 +56,7 @@ func (p *Policy) Evaluate(
 		return err
 	}
 
-	return p.Node.evaluate(nodePublicKey, peerNode)
+	return p.Node.evaluate(node, peerNode)
 }
 
 func (p *Policy) checkRejectAll() bool {

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestEvaluatePolicy(t *testing.T) {
-	nodePublicKey := "node_public_key"
+	node := &lnrpc.GetInfoResponse{IdentityPubkey: "node_public_key"}
 	peerPublicKey := "peer_public_key"
 	defaultReq := &lnrpc.ChannelAcceptRequest{}
 	defaultPeer := &lnrpc.NodeInfo{
@@ -141,7 +141,7 @@ func TestEvaluatePolicy(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := tc.policy.Evaluate(tc.req, nodePublicKey, tc.peer)
+			err := tc.policy.Evaluate(tc.req, node, tc.peer)
 			if tc.fail {
 				assert.NotNil(t, err)
 			} else {


### PR DESCRIPTION
## Description

Adds the `node.age` field to filter nodes by their age, represented in blocks.

The age is determined by doing: `bestBlockHeight - oldestAnnouncedChannelBlockHeight`.

> [!Note]
> [Related discussion on stacker.news](https://stacker.news/items/350002)