### PR TITLE
Add RPC timeout configuration field

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Configuration schema:
 | Key | Type | Required | Description |
 | -- | -- | -- | -- |
 | **rpc_address** | string | ✔ | LND GRPC address (`host:port`) |
+| **rpc_timeout** | duration | ✖ | LND GRPC connection timeout.  Set it to `0` for no timeout. Default: `60s` |
 | **certificate_path** | string | ✔ | Path to LND's TLS certificate |
 | **macaroon_path** | string | ✔ | Path to the macaroon file. See [macaroon](#macaroon) |
 | **policies** | [][Policy](#policy) | ✖ | Set of policies to enforce |

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"time"
 
 	"github.com/aftermath2/acceptlnd/policy"
 
@@ -13,10 +14,11 @@ import (
 
 // Config is acceptLND's configuration schema.
 type Config struct {
-	RPCAddress      string           `yaml:"rpc_address"`
-	CertificatePath string           `yaml:"certificate_path"`
-	MacaroonPath    string           `yaml:"macaroon_path"`
-	Policies        []*policy.Policy `yaml:"policies"`
+	RPCAddress      string           `yaml:"rpc_address,omitempty"`
+	RPCTimeout      *time.Duration   `yaml:"rpc_timeout,omitempty"`
+	CertificatePath string           `yaml:"certificate_path,omitempty"`
+	MacaroonPath    string           `yaml:"macaroon_path,omitempty"`
+	Policies        []*policy.Policy `yaml:"policies,omitempty"`
 }
 
 // Load reads the configuration file and returns a new object.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/aftermath2/acceptlnd/policy"
 
@@ -50,6 +51,7 @@ func TestLoad(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	tru := true
+	timeout := 40 * time.Second
 
 	cases := []struct {
 		desc   string
@@ -60,6 +62,7 @@ func TestValidate(t *testing.T) {
 			desc: "Valid",
 			config: Config{
 				RPCAddress:      "127.0.0.1:10001",
+				RPCTimeout:      &timeout,
 				CertificatePath: "./testdata/tls.mock",
 				MacaroonPath:    "./testdata/acceptlnd.mock",
 				Policies: []*policy.Policy{

--- a/config/testdata/config.yml
+++ b/config/testdata/config.yml
@@ -1,4 +1,5 @@
 rpc_address: 127.0.0.1:10001
+rpc_timeout: 120s
 certificate_path: ./testdata/tls.mock
 macaroon_path: ./testdata/acceptlnd.mock
 policies:

--- a/examples/configuration.yml
+++ b/examples/configuration.yml
@@ -1,0 +1,11 @@
+rpc_address: 127.0.0.1:10001
+certificate_path: tls.cert
+macaroon_path: acceptlnd.macaroon
+rpc_timeout: 1m30s
+
+--
+
+rpc_address: 127.0.0.1:10001
+certificate_path: /home/username/tls.cert
+macaroon_path: /home/username/acceptlnd.macaroon
+rpc_timeout: 90s


### PR DESCRIPTION
## Description

Adds the `rpc_timeout` configuration field so users can set custom values based on their environment resources. The default value is 60 seconds and the timeout can be disabled by setting the field value to `0|0s|0m|0h|0d`.