### PR TITLE
Add zero conf channels handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Configuration schema:
 | Key | Type | Required | Description |
 | -- | -- | -- | -- |
 | **rpc_address** | string | ✔ | LND GRPC address (`host:port`) |
-| **rpc_timeout** | duration | ✖ | LND GRPC connection timeout.  Set it to `0` for no timeout. Default: `60s` |
+| **rpc_timeout** | duration | ✖ | LND GRPC connection timeout. Valid units are {ms, s, m, h}. Use `0` for no timeout. Default: `60s` |
 | **certificate_path** | string | ✔ | Path to LND's TLS certificate |
 | **macaroon_path** | string | ✔ | Path to the macaroon file. See [macaroon](#macaroon) |
 | **policies** | [][Policy](#policy) | ✖ | Set of policies to enforce |
@@ -78,8 +78,9 @@ A policy would only be enforced if its conditions are satisfied, or if it has no
 | **reject_all** | boolean | Reject all channel requests |
 | **whitelist** | []string | List of nodes public keys whose requests will be accepted |
 | **blacklist** | []string | List of nodes public keys whose requests will be rejected |
+| **accept_zero_conf_channels** | boolean | Whether to accept zero confirmation channels |
+| **zero_conf_list** | []string | List of nodes public keys whose zero conf requests will be accepted. Requires `accept_zero_conf_channels` to be `true` | 
 | **reject_private_channels** | boolean | Whether private channels should be rejected |
-| **reject_zero_conf_channels** | boolean | Whether to reject zero confirmation channels |
 | **request** | [Request](#request) | Parameters related to the channel opening request |
 | **node** | [Node](#node) | Parameters related to the channel initiator |
 

--- a/examples/reject.yml
+++ b/examples/reject.yml
@@ -6,12 +6,6 @@ policies:
 
 policies:
   -
-    reject_zero_conf_channels: true
-
---
-
-policies:
-  -
     blacklist:
       - public_key_1
       - public_key_2


### PR DESCRIPTION
## Description

Introduces changes to explicitly accept zero confirmation channels.

## Tests

Alice: `0274fd9751f0e448c4ba91915b42ea23daee89c35af1db5fed09bb1c00d151655c`
Bob: `02759d1508e3dceb14bf985c82c3071e9a2c9e2ee8f5ea6a412c010d1d7c206149`

Command from Bob's LND

```console
lncli openchannel --node_key 0274fd9751f0e448c4ba91915b42ea23daee89c35af1db5fed09bb1c00d151655c --local_amt 100000 --zero_conf --channel_type "anchors"
```

### Cases

<details><summary>Reject zero conf</summary>

```yaml
policies:
  -
    accept_zero_conf_channels: false
```

```console
[lncli] rpc error: code = Unknown desc = received funding error from 0274fd9751f0e448c4ba91915b42ea23daee89c35af1db5fed09bb1c00d151655c: chan_id=8dcd04552b50212ed42f1ec0e8c03c1990dfa5f32974a18de30bda0295cb105b, err=Zero conf channels are not accepted
```

```console
time=2023-12-18Thh level=INFO msg="New request received" accepted=false id=8dcd04552b50212ed42f1ec0e8c03c1990dfa5f32974a18de30bda0295cb105b public_key=02759d1508e3dceb14bf985c82c3071e9a2c9e2ee8f5ea6a412c010d1d7c206149 error="Zero conf channels are not accepted"
```

</details>


<details><summary>Accept zero conf</summary>

```yaml
policies:
  -
    accept_zero_conf_channels: true
```

```console
{
        "funding_txid": "8b53725722487a628927b08fb7159321ab839845981b7b5c048e182467bf4a01"
}
```

```console
time=2023-12-18Thh level=INFO msg="New request received" accepted=true id=8feedeea61ad3ca5d9cefb4a21f3909b375deebfdae777cafd3e4a4fb0fcd913 public_key=02759d1508e3dceb14bf985c82c3071e9a2c9e2ee8f5ea6a412c010d1d7c206149
```

</details>

<details><summary>Accept zero conf, not in list</summary>

```yaml
policies:
  -
    accept_zero_conf_channels: true
    zero_conf_list:
      - 0274fd9751f0e448c4ba91915b42ea23daee89c35af1db5fed09bb1c00d151655c
```

```console
[lncli] rpc error: code = Unknown desc = received funding error from 0274fd9751f0e448c4ba91915b42ea23daee89c35af1db5fed09bb1c00d151655c: chan_id=4abfa5340ec57de90ee823c274246faf843093594a11fcdf28e4674f0fbfdf0c, err=Zero conf channels are not accepted
```

```console
time=2023-12-18Thh level=INFO msg="New request received" accepted=false id=4abfa5340ec57de90ee823c274246faf843093594a11fcdf28e4674f0fbfdf0c public_key=02759d1508e3dceb14bf985c82c3071e9a2c9e2ee8f5ea6a412c010d1d7c206149 error="Zero conf channels are not accepted"
```

</details>

<details><summary>Accept zero conf, in list</summary>

```yaml
policies:
  -
    accept_zero_conf_channels: true
    zero_conf_list:
      - 02759d1508e3dceb14bf985c82c3071e9a2c9e2ee8f5ea6a412c010d1d7c206149
```

```console
{
        "funding_txid": "a504f88aeb5f909e6e70046c9563d3bdbd8797a71775a1e03bcb8f9c0d3f8f1a"
}
```

```console
time=2023-12-18Thh level=INFO msg="New request received" accepted=true id=3a60037dda2a27015b76b53c26041ce623e1917dd5f67b353a0480796893b4d9 public_key=02759d1508e3dceb14bf985c82c3071e9a2c9e2ee8f5ea6a412c010d1d7c206149
```

</details>
