### PR TITLE
Add min accept depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A policy would only be enforced if its conditions are satisfied, or if it has no
 | **accept_zero_conf_channels** | boolean | Whether to accept zero confirmation channels |
 | **zero_conf_list** | []string | List of nodes public keys whose zero conf requests will be accepted. Requires `accept_zero_conf_channels` to be `true` | 
 | **reject_private_channels** | boolean | Whether private channels should be rejected |
+| **min_accept_depth** | int | Number of confirmations required before considering the channel open |
 | **request** | [Request](#request) | Parameters related to the channel opening request |
 | **node** | [Node](#node) | Parameters related to the channel initiator |
 

--- a/examples/channels.yml
+++ b/examples/channels.yml
@@ -7,11 +7,10 @@ policies:
           number:
             min: 10
             max: 50
-    policies:
-      request:
-        channel_capacity:
-          min: 1_000_000
-          max: 3_000_000
+    request:
+      channel_capacity:
+        min: 1_000_000
+        max: 3_000_000
 	-
     conditions:
       node:
@@ -19,18 +18,16 @@ policies:
           number:
             min: 50
             max: 200
-    policies:
-      request:
-        channel_capacity:
-          min: 3_000_000
-          max: 10_000_000
+    request:
+      channel_capacity:
+        min: 3_000_000
+        max: 10_000_000
 	-
     conditions:
       node:
         channels:
           number:
             min: 200
-    policies:
-      request:
-        channel_capacity:
-          min: 10_000_000
+    request:
+      channel_capacity:
+        min: 10_000_000

--- a/examples/simple.yml
+++ b/examples/simple.yml
@@ -1,5 +1,6 @@
 policies:
-  - 
+  -
+    min_accept_depth: 6
     request:
       channel_capacity:
         min: 3_000_000

--- a/main.go
+++ b/main.go
@@ -122,9 +122,15 @@ func handleRequest(
 		if err := policy.Evaluate(req, node, peer); err != nil {
 			return resp, err
 		}
+
+		if policy.MinAcceptDepth != nil {
+			resp.MinAcceptDepth = *policy.MinAcceptDepth
+		}
 	}
 
-	if req.WantsZeroConf {
+	if req.WantsZeroConf && len(config.Policies) != 0 {
+		// The initiator requested a zero conf channel and it was explicitly accepted, set the
+		// fields required to open it
 		resp.ZeroConf = true
 		resp.MinAcceptDepth = 0
 	}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -21,6 +21,7 @@ type Policy struct {
 	RejectAll              *bool       `yaml:"reject_all,omitempty"`
 	RejectPrivateChannels  *bool       `yaml:"reject_private_channels,omitempty"`
 	AcceptZeroConfChannels *bool       `yaml:"accept_zero_conf_channels,omitempty"`
+	MinAcceptDepth         *uint32     `yaml:"min_accept_depth,omitempty"`
 }
 
 // Evaluate set of policies.


### PR DESCRIPTION
## Description

Adds a field to select the minimum accepted depth before a channel is considered open.

Each policy can have a different `min_accept_depth` value to allow for further customization, in case many policies match, the value from the last one is used. If `accept_zero_conf_channels` is `true`, it is set to `0`.